### PR TITLE
dev: remove unused variable diff and deprecated get_message_xml

### DIFF
--- a/cib.go
+++ b/cib.go
@@ -57,7 +57,6 @@ static void go_cib_notify_cb(const char *event, xmlNode * msg) {
 	rc = pcmk_ok;
 
 	xmlNode *current_cib;
-	xmlNode *diff = get_message_xml(msg, F_CIB_UPDATE_RESULT);
 
 	s_cib->cmds->query(s_cib, NULL, &current_cib, cib_scope_local | cib_sync_call);
 


### PR DESCRIPTION
It's safe because `diff` is never used and `get_message_xml` has no side-effect. And what's most important the `get_message_xml` is deprecated and dropped from pacemaker-3.0.0.