### PR TITLE
fix: #include <crm/crm.h> to import LOG_CRIT, crm_log_init, crm_syste…

### DIFF
--- a/pacemaker.go
+++ b/pacemaker.go
@@ -15,6 +15,7 @@ import (
 /*
 #cgo pkg-config: libxml-2.0 glib-2.0 libqb pacemaker pacemaker-cib
 #include <crm/cib.h>
+#include <crm/crm.h>
 #include <crm/services.h>
 #include <crm/common/util.h>
 #include <crm/common/xml.h>


### PR DESCRIPTION
`#include <crm/crm.h>` was removed from `nvpair.h` in ClusterLabs/pacemaker@f9a7c337 and transitively broke dependencies on `LOG_CRIT, crm_log_init, and crm_system_name`. Here the `<crm/crm.h>` is included explicitely.